### PR TITLE
Add security_opt in dockercompose.yml

### DIFF
--- a/docker-compose/Dedicated-Server/docker-compose.yml
+++ b/docker-compose/Dedicated-Server/docker-compose.yml
@@ -31,5 +31,8 @@ services:
       #- '5002:5002/udp' # Uncomment to enable DCS SimpleRadio Standalone (DCS-SRS) - TCP and UDP.      
     volumes:
       - '${HOME}/dcs-world-dedicated-server:/config/'
+    security_opt:
+      #Security_opt is neccesary to prevent the 'Failed to execute child process "bash": Failed to fdwalk: Operation not permitted' error on attempting to launch any terminal applications within the image
+      - seccomp=unconfined
     restart: always
     image: aterfax/dcs-world-dedicated-server


### PR DESCRIPTION
The terminal within the docker image is unable to execute any bash commands due to a privilege issue. 
See the following [link](https://github.com/mviereck/x11docker/issues/346) and a followup [here](https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/94).