### PR TITLE
Add hotfix to allow login to work.

### DIFF
--- a/docker/src/s6-services/s6-init-winepreqs-oneshot/run
+++ b/docker/src/s6-services/s6-init-winepreqs-oneshot/run
@@ -25,11 +25,17 @@ lsiown -R abc:users /config/.cache
 
 sudo -u abc winecfg
 
+# Add required DLL overrides
+echo "Installing Wine DLL overrides"
+sudo -u abc /usr/bin/wine reg add 'HKCU\Software\Wine\DllOverrides' /v wbemprox /t REG_SZ /d 'native' /f
+
 # Install the wine dependencies.
 # Note that this will not reinstall the dependencies if they are already installed.
 sudo -u abc /usr/bin/winetricks --unattended d3dcompiler_43 
 sudo -u abc /usr/bin/winetricks --unattended d3dx11_43 
 sudo -u abc /usr/bin/winetricks --unattended d3dcompiler_47 
 sudo -u abc /usr/bin/winetricks --unattended win10 
-echo "Exiting" 
+
+echo "Wine installations complete, Exiting." 
+
 exit 0


### PR DESCRIPTION
Closes https://github.com/Aterfax/DCS-World-Dedicated-Server-Docker/issues/61

Tested and appears to be working for a full new installation.
Adding the registry entry over and over with each container start does not appear to cause any issues so going to merge this in an expedient fashion.

Note that registry edits seem to need to be performed before the installs to avoid some kind of blocking issue preventing subsequent services starting up (i.e. starting the server.)

Hope folks get to exploring Kola now!