### PR TITLE
Update modular server downloading logic.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Force permissions fix.
         run: sudo apt-get update && sudo apt-get install dos2unix -y && cd docker && bash dos2unix.sh
 
+      - name: Check DL link still working.
+        run: source docker/src/helper_functions/get_dl_link
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Force permissions fix.
         run: sudo apt-get update && sudo apt-get install dos2unix -y && cd docker && bash dos2unix.sh
 
+      - name: Check DL link still working.
+        run: source docker/src/helper_functions/get_dl_link
+
       # setup Docker build action
       - name: Set up Docker Buildx
         id: buildx

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ FROM lscr.io/linuxserver/webtop:latest
 LABEL maintainer="Aterfax"
 
 # Wine 64Bit for running EXE
-RUN apk add --no-cache wine freetype wget cabextract xdotool xdg-utils xvfb xvfb-run git python3 python3-dev py3-pip 7zip make cmake gcc g++ gfortran innoextract
+RUN apk add --no-cache wine freetype wget cabextract xdotool xdg-utils xvfb xvfb-run git python3 python3-dev py3-pip 7zip make cmake gcc g++ gfortran innoextract grep
 
 # Download the latest winetricks script (master="latest version") from Github.
 RUN wget https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks && chmod +x winetricks
@@ -45,6 +45,9 @@ RUN chmod +x -R /app/dcs_server/logger_function
 
 COPY ./src/helper_functions/find_dcs_dirs_function /app/dcs_server/find_dcs_dirs_function
 RUN chmod +x -R /app/dcs_server/find_dcs_dirs_function
+
+COPY ./src/helper_functions/get_dl_link /app/dcs_server/get_dl_link
+RUN chmod +x -R /app/dcs_server/get_dl_link
 
 # Add branding here to avoid it getting split into pieces in the output.
 COPY ./src/branding /etc/s6-overlay/s6-rc.d/init-adduser/branding2

--- a/docker/src/helper_functions/get_dl_link
+++ b/docker/src/helper_functions/get_dl_link
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+DOMAIN_ROOT="https://www.digitalcombatsimulator.com"
+DL_PAGE="${DOMAIN_ROOT}/en/downloads/world/server/"
+MODULAR_SERVER_DL_URL=${DOMAIN_ROOT}$(curl -s ${DL_PAGE} | grep 'DCS_World_Server_modular.exe' | grep -Po '(?<=href=")[^"]*')
+MODULAR_SERVER_MD5SUM=$(curl -s "$DL_PAGE" | grep -o 'MD5:</b> [a-f0-9]\+' | awk '{print $2}')
+
+# Check if the download URL is empty (no match found)
+if [[ -z "$MODULAR_SERVER_DL_URL" ]]; then
+  echo "Error: Could not find DCS_World_Server_modular.exe on download page."
+  exit 1
+fi
+
+# Check the response of the download URL for a valid endpoint
+RESPONSE=$(curl -fsSI "$MODULAR_SERVER_DL_URL")
+echo "$RESPONSE" | grep -q 'HTTP/2 200'
+
+if [[ $? -ne 0 ]]; then
+  echo "Error: Download URL might be invalid or unreachable."
+  exit 1
+fi
+
+# Also check for the presence of the expected MIME type (optional)
+EXPECTED_MIME_TYPE="application/octet-stream"
+MIME_TYPE=$(echo "$RESPONSE" | grep -i 'Content-Type:' | cut -d':' -f2 | tr -d '[:space:]')
+
+if [[ -n "$EXPECTED_MIME_TYPE" && "$MIME_TYPE" != "$EXPECTED_MIME_TYPE" ]]; then
+  echo "Warning: Downloaded content is not be the expected type ($EXPECTED_MIME_TYPE)."
+  exit 1
+else
+  echo "Modular server download link seems valid. Proceeding..."
+fi
+
+export MODULAR_SERVER_DL_URL="${MODULAR_SERVER_DL_URL}"
+export MODULAR_SERVER_MD5SUM="${MODULAR_SERVER_MD5SUM}"

--- a/docker/src/s6-services/s6-init-getlatest-dcs-installer-oneshot/run
+++ b/docker/src/s6-services/s6-init-getlatest-dcs-installer-oneshot/run
@@ -39,11 +39,14 @@ download_dcs_server() {
 # Enable immediate exit on error
 set -e
 
-URL="https://www.digitalcombatsimulator.com/upload/iblock/17c/slq6u1srmqqi1fb2oaofz1qx6vc5p2fh/DCS_World_Server_modular.exe"
+# Source the helper function - this will populate the variable $MODULAR_SERVER_DL_URL and $MODULAR_SERVER_MD5SUM
+source /app/dcs_server/get_dl_link
+
+URL="${MODULAR_SERVER_DL_URL}"
 DOWNLOAD_PATH="/config/DCS_World_Server_modular.exe"
 
 # Note that this method of grabbing the MD5 checksum is fairly brittle!
-MD5SUM=$(curl -s "https://www.digitalcombatsimulator.com/en/downloads/world/server/" | grep -o 'MD5:</b> [a-f0-9]\+' | awk '{print $2}')
+MD5SUM="${MODULAR_SERVER_MD5SUM}"
 DOWNLOADED_MD5SUM=$(md5sum "$DOWNLOAD_PATH" | awk '{print $1}')
 
 echo -e "Downloading DCS Server install executable if required: " 


### PR DESCRIPTION
Updates logic to acquire the download link and MD5sum from the hopefully static download page.

Should account for the infrequent download link changes.

Also enforces valid download link checks as part of CI/CD so regular checks occur.

Closes https://github.com/Aterfax/DCS-World-Dedicated-Server-Docker/issues/67