### PR TITLE
Remove redundant vcrun2022 installation command

### DIFF
--- a/docker/src/s6-services/s6-init-dcssb-auto-installer-updater-oneshot/run
+++ b/docker/src/s6-services/s6-init-dcssb-auto-installer-updater-oneshot/run
@@ -36,7 +36,9 @@ fi
 # Avoid issue with Python hitting an error as:
 # wine: Unimplemented function ucrtbase.dll.crealf called at address ...
 
-sudo -u abc /usr/bin/winetricks --unattended vcrun2017 
+# Next line no longer needed due to default vcrun2022 install via main docker
+# See: https://github.com/Aterfax/DCS-World-Dedicated-Server-Docker/pull/132
+# sudo -u abc /usr/bin/winetricks --unattended vcrun2022 
 
 # Note single quotes 'EOF' to prevent variable expansion.
 sudo -E -u abc bash <<'EOF'


### PR DESCRIPTION
Removed unnecessary winetricks command for vcrun2022 due to default installation.